### PR TITLE
Add nix flake for development environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nix-config/*
 config.json
 bin
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -48,4 +48,21 @@ total 2552
 -rw-r--r--@ 1 patrik.koska  staff   2228 Feb 17 04:40 12-configuration.nix
 ```
 
+## Setting up a development environment
+If you have nix installed and flakes enabled, you can start a minimal environment with
+`nix develop` from the repository root
+
+
+```
+➜  nixconfig-go git:(develop) ✗ nix develop     
+warning: Git tree '/home/pkoska/nixconfig-go' is dirty
+
+[pkoska@nixos:~/nixconfig-go]$ which go
+/nix/store/zg65r8ys8y5865lcwmmybrq5gn30n1az-go-1.21.6/bin/go
+
+[pkoska@nixos:~/nixconfig-go]$ go version
+go version go1.21.6 linux/amd64
+
+```
+
 **GL with hunting!**

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707956935,
+        "narHash": "sha256-ZL2TrjVsiFNKOYwYQozpbvQSwvtV/3Me7Zwhmdsfyu4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a4d4fe8c5002202493e87ec8dbc91335ff55552c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "Basic environment for nixconfig-go";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            pkgs.go
+            pkgs.git
+          ];
+          
+          shellHook = ''
+            export GOPATH=$PWD/.gopath
+            export PATH=$GOPATH/bin:$PATH
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
flake.nix and flake.lock was added to the project so a development environment can be spin up with `nix develop`